### PR TITLE
Fix facade registration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,7 @@
                 "Spatie\\BladeX\\BladeXServiceProvider"
             ],
             "aliases": {
-                "BladeX": "Spatie\\BladeX\\Facedes\\BladeX"
+                "BladeX": "Spatie\\BladeX\\Facades\\BladeX"
             }
         }
     }


### PR DESCRIPTION
Correct "Facades" spelling in path for BladeX alias/facade.