### PR TITLE
change markdown code type from html to blade in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ BladeX support slots too. This layout component
 
 can be used in your views like this:
 
-```html
+```blade
 <layout title="Zed's chopper">
     <slot name="sidebar">
         <ul>


### PR DESCRIPTION
This will fix the issue with HTML snippet type on Github markdown preview where invalid HTML is highlighted in red.