### PR TITLE
Show how to register *all* views at once...

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,14 @@ You can also register an entire directory like this.
 BladeX::components('components')
 ```
 
+If you would like to register your entire `views` directory, you can do so like this:
+
+```php
+// This will register all Blade views that are stored in `resources/views`
+
+BladeX::components('.')
+```
+
 In your Blade view you can now use the component using the kebab-cased name:
 
 ```blade


### PR DESCRIPTION
I'm not 100% sure if this is a good thing, but I didn't want to have to pick one particular view folder or register several different folders (which might also be a nice feature, btw), so I wanted to see if I could just register all views in my views folder.  It made sense to register the components using directory `'.'`, and it seems to work fine.  So, I thought it could be helpful to other developers who may want to do so to have this "special" circumstance briefly described in the docs.

No code changes....but I may take a look at being able to pass an array into `BladeX::components()` to register multiple paths/folders at once.

If there are good reasons to not do/allow either of these things, please let me know.

And...thanks again for all you guys at Spatie do.  :-)