### PR TITLE
Updated docs to cover multiple directory registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,14 @@ You can also register an entire directory like this.
 BladeX::components('components')
 ```
 
+Or you can register multiple directories like this.
+
+```php
+// This will register all Blade views that are stored in both `resources/views/components` and `resources/views/layouts`
+
+BladeX::components(['components', 'layouts'])
+```
+
 In your Blade view you can now use the component using the kebab-cased name:
 
 ```blade
@@ -152,7 +160,7 @@ Before reviewing the contents of the component and the view model itself, let's 
 
 ```html
 @php
-// In a real app this data would probably come from a controller 
+// In a real app this data would probably come from a controller
 // or a view composer.
 $countries = [
     'be' => 'Belgium',
@@ -237,9 +245,9 @@ You can rewrite the above as
 ```html
 <context :model="$user">
     <input-field name="first_name" />
-    
+
     <input-field name="last_name" />
-    
+
     <input-field name="email" />
 </context>
 ```


### PR DESCRIPTION
I added a brief description to the readme file on how one registers multiple component directories at once.  It looks like my IDE also cleaned up a bit of trailing whitespace for some bonus points.