### PR TITLE
Spaces in slots

### DIFF
--- a/src/BladeXCompiler.php
+++ b/src/BladeXCompiler.php
@@ -160,7 +160,7 @@ class BladeXCompiler
         return preg_replace_callback($pattern, function ($regexResult) {
             [$slot, $name, $contents] = $regexResult;
 
-            return "@slot('{$name}'){$contents}@endslot";
+            return " @slot('{$name}') {$contents} @endslot ";
         }, $viewContents);
     }
 

--- a/tests/Features/ComponentCompilation/ComponentCompilationTest.php
+++ b/tests/Features/ComponentCompilation/ComponentCompilationTest.php
@@ -56,6 +56,14 @@ class ComponentCompilationTest extends TestCase
     }
 
     /** @test */
+    public function it_compiles_a_component_with_no_spaces()
+    {
+        BladeX::component('components.heading');
+
+        $this->assertMatchesViewSnapshot('componentWithNoSpaces');
+    }
+
+    /** @test */
     public function it_compiles_a_component_with_variables()
     {
         BladeX::component('components.card');

--- a/tests/Features/ComponentCompilation/__snapshots__/ComponentCompilationTest__it_compiles_a_component_with_no_spaces__1.xml
+++ b/tests/Features/ComponentCompilation/__snapshots__/ComponentCompilationTest__it_compiles_a_component_with_no_spaces__1.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<div>
+  <div>
+    <div>
+      <h6>
+                Components
+            </h6>
+      <h1>
+            Alerts
+        </h1>
+    </div>
+  </div>
+  <div>
+    <div>
+      <h1>
+            Alerts
+        </h1>
+    </div>
+  </div>
+</div>

--- a/tests/Features/ComponentCompilation/__snapshots__/ComponentCompilationTest__it_compiles_a_component_with_no_spaces__2.xml
+++ b/tests/Features/ComponentCompilation/__snapshots__/ComponentCompilationTest__it_compiles_a_component_with_no_spaces__2.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<div><?php $__env->startComponent(
+           'components/heading',
+           array_merge(app(Spatie\BladeX\ContextStack::class)->read(), [])); ?><?php $__env->slot('subheader'); ?> Components <?php $__env->endSlot(); ?> Alerts <?php echo $__env->renderComponent(); ?>
+<?php $__env->startComponent(
+           'components/heading',
+           array_merge(app(Spatie\BladeX\ContextStack::class)->read(), [])); ?>Alerts <?php echo $__env->renderComponent(); ?></div>

--- a/tests/Features/ComponentCompilation/__snapshots__/ComponentCompilationTest__it_compiles_a_component_with_scoped_slots__2.xml
+++ b/tests/Features/ComponentCompilation/__snapshots__/ComponentCompilationTest__it_compiles_a_component_with_scoped_slots__2.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0"?>
 <div><?php $__env->startComponent(
            'components/layout',
-           array_merge(app(Spatie\BladeX\ContextStack::class)->read(), ['title' => 'Zed\'s Chopper'])); ?><?php $__env->slot('sidebar'); ?><ul><li>Home</li><li>Contact</li></ul><?php $__env->endSlot(); ?><main class="content">Whose chopper is this?</main><?php $__env->slot('footer'); ?>It's Zed's.<?php $__env->endSlot(); ?><?php echo $__env->renderComponent(); ?></div>
+           array_merge(app(Spatie\BladeX\ContextStack::class)->read(), ['title' => 'Zed\'s Chopper'])); ?><?php $__env->slot('sidebar'); ?><ul><li>Home</li><li>Contact</li></ul><?php $__env->endSlot(); ?><main class="content">Whose chopper is this?</main><?php $__env->slot('footer'); ?> It's Zed's. <?php $__env->endSlot(); ?> 
+ <?php echo $__env->renderComponent(); ?>
+</div>

--- a/tests/Features/ComponentCompilation/stubs/components/heading.blade.php
+++ b/tests/Features/ComponentCompilation/stubs/components/heading.blade.php
@@ -1,0 +1,12 @@
+<div>
+    <div>
+        @isset($subheader)
+            <h6>
+                {{ $subheader }}
+            </h6>
+        @endisset
+        <h1>
+            {{ $slot }}
+        </h1>
+    </div>
+</div>

--- a/tests/Features/ComponentCompilation/stubs/views/componentWithNoSpaces.blade.php
+++ b/tests/Features/ComponentCompilation/stubs/views/componentWithNoSpaces.blade.php
@@ -1,0 +1,2 @@
+<heading><slot name="subheader">Components</slot>Alerts</heading>
+<heading>Alerts</heading>


### PR DESCRIPTION
Let me try and explain what's happening here:

When you have a component, and it has a slot, it creates a blade tag.
```
@component
@slot
Slot
@endslot
Text
@endcomponent
```

When you do not have spaces around the slot, you encounter a render error, as the slot is not being parsed correctly with the spaces:
```
    <div>
      <h6>
                
            </h6>
      <h1>
            Slot@endslot Text
        </h1>
    </div>
```

I may be doing something wrong of course, but this is causing issues for me when I write tags like so:
```
<heading><slot name="subheader">Components</slot>Alerts</heading>
```