### PR TITLE
[Feature] Add support subdirectories in a vendor namespace and global prefix (fixes #60)

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -60,6 +60,11 @@ class Component
 
         $tag = kebab_case(end($baseComponentName));
 
+        if (str_contains($view, '::') && !str_contains($tag, '::')) {
+            $namespace = array_first(explode('::', $view));
+            $tag = "{$namespace}::{$tag}";
+        }
+
         return $tag;
     }
 }

--- a/src/Component.php
+++ b/src/Component.php
@@ -60,7 +60,7 @@ class Component
 
         $tag = kebab_case(end($baseComponentName));
 
-        if (str_contains($view, '::') && !str_contains($tag, '::')) {
+        if (str_contains($view, '::') && ! str_contains($tag, '::')) {
             $namespace = array_first(explode('::', $view));
             $tag = "{$namespace}::{$tag}";
         }

--- a/src/ComponentDirectory/NamespacedDirectory.php
+++ b/src/ComponentDirectory/NamespacedDirectory.php
@@ -31,7 +31,7 @@ class NamespacedDirectory extends ComponentDirectory
             throw CouldNotRegisterComponent::viewPathNotFound($viewPath);
         }
 
-        return $absoluteDirectory;
+        return $viewPath ? "{$absoluteDirectory}/{$viewPath}" : $absoluteDirectory;
     }
 
     public function getViewName(SplFileInfo $viewFile): string

--- a/tests/Features/ComponentCompilation/ComponentCompilationTest.php
+++ b/tests/Features/ComponentCompilation/ComponentCompilationTest.php
@@ -116,6 +116,18 @@ class ComponentCompilationTest extends TestCase
     }
 
     /** @test */
+    public function a_global_prefix_works_with_namespaced_component()
+    {
+        View::addNamespace('namespaced-components', __DIR__.'/stubs/namespacedComponents');
+
+        BladeX::component('namespaced-components::namespacedCard');
+
+        BladeX::prefix('x');
+
+        $this->assertMatchesViewSnapshot('namespacedGlobalPrefix');
+    }
+
+    /** @test */
     public function it_compiles_components_that_use_a_global_function()
     {
         BladeX::component('components.card');

--- a/tests/Features/ComponentCompilation/__snapshots__/ComponentCompilationTest__a_global_prefix_works_with_namespaced_component__1.xml
+++ b/tests/Features/ComponentCompilation/__snapshots__/ComponentCompilationTest__a_global_prefix_works_with_namespaced_component__1.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<div>
+  <div class="card">
+    <h1>Profile</h1>
+    <div>My content</div>
+  </div>
+</div>

--- a/tests/Features/ComponentCompilation/__snapshots__/ComponentCompilationTest__a_global_prefix_works_with_namespaced_component__2.xml
+++ b/tests/Features/ComponentCompilation/__snapshots__/ComponentCompilationTest__a_global_prefix_works_with_namespaced_component__2.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<div><?php $__env->startComponent(
+           'namespaced-components::namespacedCard',
+           array_merge(app(Spatie\BladeX\ContextStack::class)->read(),
+           ['title' => 'Profile'])
+        ); ?> 
+    My content
+ <?php echo $__env->renderComponent(); ?> 
+</div>

--- a/tests/Features/ComponentCompilation/stubs/namespacedComponents/namespacedCard.blade.php
+++ b/tests/Features/ComponentCompilation/stubs/namespacedComponents/namespacedCard.blade.php
@@ -1,0 +1,4 @@
+<div class="card">
+    <h1>{!! is_array($title) ? $title[0] : $title !!}</h1>
+    <div>{{ $slot }}</div>
+</div>

--- a/tests/Features/ComponentCompilation/stubs/views/namespacedGlobalPrefix.blade.php
+++ b/tests/Features/ComponentCompilation/stubs/views/namespacedGlobalPrefix.blade.php
@@ -1,0 +1,3 @@
+<x-namespaced-components::namespaced-card title="Profile">
+    My content
+</x-namespaced-components::namespaced-card>

--- a/tests/Features/Registration/RegistrationTest.php
+++ b/tests/Features/Registration/RegistrationTest.php
@@ -167,6 +167,25 @@ class RegistrationTest extends TestCase
     }
 
     /** @test */
+    public function it_can_register_a_subdirectory_containing_namespaced_view_components()
+    {
+        View::addNamespace('subdirectory-namespaced-test', __DIR__.'/stubs/components/namespacedComponents');
+
+        BladeX::component('subdirectory-namespaced-test::components.*');
+
+        $registeredComponents = collect(BladeX::registeredComponents())
+            ->mapWithKeys(function (Component $bladeXComponent) {
+                return [$bladeXComponent->tag => $bladeXComponent->view];
+            })
+            ->toArray();
+
+        $this->assertEquals([
+            'context' => 'bladex::context',
+            'subdirectory-namespaced-test::namespaced-view1' => 'subdirectory-namespaced-test::components.namespacedView1',
+        ], $registeredComponents);
+    }
+
+    /** @test */
     public function it_overwrites_the_previous_component_when_registering_one_with_the_same_name()
     {
         BladeX::component('components.directoryWithComponents.myView1', 'foo');

--- a/tests/Features/Registration/stubs/components/namespacedComponents/components/namespacedView1.blade.php
+++ b/tests/Features/Registration/stubs/components/namespacedComponents/components/namespacedView1.blade.php
@@ -1,0 +1,1 @@
+namespaced with subdirectory view 1


### PR DESCRIPTION
Dear,

This is my first PR , PR support add subdirectories in vendor namespace.

Register:

```
BladeX::component('vendor::components.blocks.*');
```

Views:

```
<vendor::sample-component />
```

Also if has global prefix: `BladeX::prefix('x')`

```
<x-vendor::sample-component />
```

Sorry my bad English 😅

PR for #60