### PR TITLE
Convert all str_* and array_* helper functions to use support classes

### DIFF
--- a/src/BladeX.php
+++ b/src/BladeX.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\BladeX;
 
+use Illuminate\Support\Str;
 use Illuminate\Support\Facades\File;
 use Symfony\Component\Finder\SplFileInfo;
 use Spatie\BladeX\ComponentDirectory\RegularDirectory;
@@ -73,7 +74,7 @@ class BladeX
 
     public function getPrefix(): string
     {
-        return empty($this->prefix) ? '' : str_finish($this->prefix, '-');
+        return empty($this->prefix) ? '' : Str::finish($this->prefix, '-');
     }
 
     public function registerComponents(string $viewDirectory)
@@ -84,7 +85,7 @@ class BladeX
 
         collect(File::files($componentDirectory->getAbsoluteDirectory()))
             ->filter(function (SplFileInfo $file) {
-                return ends_with($file->getFilename(), '.blade.php');
+                return Str::endsWith($file->getFilename(), '.blade.php');
             })
             ->map(function (SplFileInfo $file) use ($componentDirectory) {
                 return $componentDirectory->getViewName($file);

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -2,6 +2,8 @@
 
 namespace Spatie\BladeX;
 
+use Illuminate\Support\Str;
+
 class Compiler
 {
     /** @var \Spatie\BladeX\BladeX */
@@ -126,18 +128,18 @@ class Compiler
         }
 
         return collect($matches)->mapWithKeys(function ($match) {
-            $attribute = camel_case($match['attribute']);
+            $attribute = Str::camel($match['attribute']);
             $value = $match['value'] ?? null;
 
             if (is_null($value)) {
                 $value = 'true';
-                $attribute = str_start($attribute, 'bind:');
+                $attribute = Str::start($attribute, 'bind:');
             }
 
             $value = $this->stripQuotes($value);
 
-            if (starts_with($attribute, 'bind:')) {
-                $attribute = str_after($attribute, 'bind:');
+            if (Str::startsWith($attribute, 'bind:')) {
+                $attribute = Str::after($attribute, 'bind:');
             } else {
                 $value = str_replace("'", "\\'", $value);
                 $value = "'{$value}'";
@@ -164,7 +166,7 @@ class Compiler
 
     protected function isOpeningHtmlTag(string $tagName, string $html): bool
     {
-        return ! ends_with($html, ["</{$tagName}>", '/>']);
+        return ! Str::endsWith($html, ["</{$tagName}>", '/>']);
     }
 
     protected function parseBindAttributes(string $attributeString): string
@@ -183,7 +185,7 @@ class Compiler
 
     protected function stripQuotes(string $string): string
     {
-        if (starts_with($string, ['"', '\''])) {
+        if (Str::startsWith($string, ['"', '\''])) {
             return substr($string, 1, -1);
         }
 

--- a/src/Component.php
+++ b/src/Component.php
@@ -3,6 +3,7 @@
 namespace Spatie\BladeX;
 
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use Illuminate\Contracts\Support\Arrayable;
 use Spatie\BladeX\Exceptions\CouldNotRegisterComponent;
 
@@ -59,9 +60,9 @@ class Component
     {
         $baseComponentName = explode('.', $view);
 
-        $tag = kebab_case(end($baseComponentName));
+        $tag = Str::kebab(end($baseComponentName));
 
-        if (str_contains($view, '::') && ! str_contains($tag, '::')) {
+        if (Str::contains($view, '::') && ! Str::contains($tag, '::')) {
             $namespace = Arr::first(explode('::', $view));
             $tag = "{$namespace}::{$tag}";
         }

--- a/src/ComponentDirectory/ComponentDirectory.php
+++ b/src/ComponentDirectory/ComponentDirectory.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\BladeX\ComponentDirectory;
 
+use Illuminate\Support\Str;
 use Symfony\Component\Finder\SplFileInfo;
 
 abstract class ComponentDirectory
@@ -10,7 +11,7 @@ abstract class ComponentDirectory
 
     public function getViewName(SplFileInfo $viewFile): string
     {
-        $view = str_replace_last('.blade.php', '', $viewFile->getFilename());
+        $view = Str::replaceLast('.blade.php', '', $viewFile->getFilename());
 
         return "{$this->viewDirectory}.{$view}";
     }

--- a/src/ComponentDirectory/NamespacedDirectory.php
+++ b/src/ComponentDirectory/NamespacedDirectory.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\BladeX\ComponentDirectory;
 
+use Illuminate\Support\Str;
 use Illuminate\Support\Facades\View;
 use Symfony\Component\Finder\SplFileInfo;
 use Spatie\BladeX\Exceptions\CouldNotRegisterComponent;
@@ -17,8 +18,7 @@ class NamespacedDirectory extends ComponentDirectory
     public function __construct(string $viewDirectory)
     {
         [$this->namespace, $viewDirectory] = explode('::', $viewDirectory);
-
-        $this->viewDirectory = str_before($viewDirectory, '*');
+        $this->viewDirectory = Str::before($viewDirectory, '*');
     }
 
     public function getAbsoluteDirectory(): string
@@ -36,7 +36,7 @@ class NamespacedDirectory extends ComponentDirectory
 
     public function getViewName(SplFileInfo $viewFile): string
     {
-        $view = str_replace_last('.blade.php', '', $viewFile->getFilename());
+        $view = Str::replaceLast('.blade.php', '', $viewFile->getFilename());
 
         $viewDirectory = '';
 

--- a/src/ComponentDirectory/RegularDirectory.php
+++ b/src/ComponentDirectory/RegularDirectory.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\BladeX\ComponentDirectory;
 
+use Illuminate\Support\Str;
 use Illuminate\Support\Facades\View;
 use Symfony\Component\Finder\SplFileInfo;
 use Spatie\BladeX\Exceptions\CouldNotRegisterComponent;
@@ -36,7 +37,7 @@ class RegularDirectory extends ComponentDirectory
 
     public function getViewName(SplFileInfo $viewFile): string
     {
-        $view = str_replace_last('.blade.php', '', $viewFile->getFilename());
+        $view = Str::replaceLast('.blade.php', '', $viewFile->getFilename());
 
         return "{$this->viewDirectory}.{$view}";
     }

--- a/src/ContextStack.php
+++ b/src/ContextStack.php
@@ -2,6 +2,8 @@
 
 namespace Spatie\BladeX;
 
+use Illuminate\Support\Arr;
+
 class ContextStack
 {
     /** @var array */
@@ -14,7 +16,7 @@ class ContextStack
 
     public function read(): array
     {
-        return array_last($this->stack) ?? [];
+        return Arr::last($this->stack) ?? [];
     }
 
     public function pop()


### PR DESCRIPTION
Laravel 5.8 [deprecates the string and array helper functions](https://laravel.com/docs/master/upgrade#string-and-array-helpers) and each
use needs to be converted to the appropriate Str/Arr helper method to stay
compatible.