### PR TITLE
Prevent closing tags from similarly named components from being parsed

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -66,7 +66,7 @@ class Compiler
     {
         $prefix = $this->bladeX->getPrefix();
 
-        $pattern = "/<\/\s*{$prefix}{$component->tag}[^>]*>/";
+        $pattern = "/<\/\s*{$prefix}{$component->tag}*>/";
 
         return preg_replace($pattern, $this->componentEndString($component), $viewContents);
     }


### PR DESCRIPTION
Fixes https://github.com/spatie/laravel-blade-x/issues/74