### PR TITLE
Loading views moved from `register` method to `boot`

### DIFF
--- a/src/BladeXServiceProvider.php
+++ b/src/BladeXServiceProvider.php
@@ -12,12 +12,12 @@ class BladeXServiceProvider extends ServiceProvider
         $this->app->singleton(ContextStack::class);
 
         $this->app->alias(BladeX::class, 'blade-x');
-
-        $this->loadViewsFrom(__DIR__.'/../resources/views', 'bladex');
     }
 
     public function boot()
     {
+        $this->loadViewsFrom(__DIR__.'/../resources/views', 'bladex');
+
         $this->app['blade.compiler']->extend(function ($view) {
             return $this->app[Compiler::class]->compile($view);
         });


### PR DESCRIPTION
Views should be loaded in `boot` method instead of `register` as described in [Package Development#Views](https://laravel.com/docs/5.8/packages#views) section. If make registration in `register` method, it may cause errors if you have custom extensions of `view` service.

In my case, I have custom `resolving` callback on `view` service in `AppServiceProvider::register`. `BladeXServiceProvider::register` called firstly and `loadViewsFrom` method resolves `view` service. Based on this my custom `resolving` callback will never be called because it will be registered after first `view` service resolving.