### PR TITLE
prefix single components and collections - allow to remove namespace

### DIFF
--- a/src/BladeX.php
+++ b/src/BladeX.php
@@ -59,6 +59,16 @@ class BladeX
     }
 
     /**
+     * @param string $viewDirectory
+     *
+     * @return \Spatie\BladeX\ComponentCollection|\Spatie\BladeX\Component[]
+     */
+    public function components(string $viewDirectory): ComponentCollection
+    {
+        return $this->registerComponents($viewDirectory);
+    }
+
+    /**
      * @return \Spatie\BladeX\Component[]
      */
     public function registeredComponents(): array
@@ -81,6 +91,8 @@ class BladeX
     }
 
     /**
+     * @internal
+     *
      * @param string $viewDirectory
      *
      * @return \Spatie\BladeX\ComponentCollection|\Spatie\BladeX\Component[]

--- a/src/BladeX.php
+++ b/src/BladeX.php
@@ -68,8 +68,8 @@ class BladeX
         if (is_iterable($viewDirectory)) {
             $components = new ComponentCollection();
 
-            foreach($viewDirectory as $singleViewDirectory) {
-                if(Str::endsWith($singleViewDirectory, '*')) {
+            foreach ($viewDirectory as $singleViewDirectory) {
+                if (Str::endsWith($singleViewDirectory, '*')) {
                     $components = $components->merge($this->registerComponents($singleViewDirectory));
                 } else {
                     $components->push($this->component($singleViewDirectory));

--- a/src/BladeX.php
+++ b/src/BladeX.php
@@ -25,16 +25,14 @@ class BladeX
      */
     public function component($view, string $tag = ''): ?Component
     {
-        if (is_array($view)) {
-            foreach ($view as $singleView) {
-                $this->component($singleView);
-            }
+        if (is_iterable($view)) {
+            $this->registerViews($view);
 
             return null;
         }
 
         if ($view instanceof Component) {
-            $this->registeredComponents[$view->tag] = $view;
+            $this->registeredComponents[] = $view;
 
             return $view;
         }
@@ -55,14 +53,19 @@ class BladeX
 
         $component = new Component($view, $tag);
 
-        $this->registeredComponents[$component->tag] = $component;
+        $this->registeredComponents[] = $component;
 
         return $component;
     }
 
+    /**
+     * @return \Spatie\BladeX\Component[]
+     */
     public function registeredComponents(): array
     {
-        return array_values($this->registeredComponents);
+        return collect($this->registeredComponents)->reverse()->unique(function (Component $component) {
+            return $component->getTag();
+        })->reverse()->values()->all();
     }
 
     public function prefix(string $prefix = ''): self
@@ -77,21 +80,37 @@ class BladeX
         return empty($this->prefix) ? '' : Str::finish($this->prefix, '-');
     }
 
-    public function registerComponents(string $viewDirectory)
+    /**
+     * @param string $viewDirectory
+     *
+     * @return \Spatie\BladeX\ComponentCollection|\Spatie\BladeX\Component[]
+     */
+    public function registerComponents(string $viewDirectory): ComponentCollection
     {
         $componentDirectory = Str::contains($viewDirectory, '::')
             ? new NamespacedDirectory($viewDirectory)
             : new RegularDirectory($viewDirectory);
 
-        collect(File::files($componentDirectory->getAbsoluteDirectory()))
-            ->filter(function (SplFileInfo $file) {
-                return Str::endsWith($file->getFilename(), '.blade.php');
-            })
-            ->map(function (SplFileInfo $file) use ($componentDirectory) {
-                return $componentDirectory->getViewName($file);
-            })
-            ->each(function (string $viewName) {
-                $this->component($viewName);
-            });
+        return $this->registerViews(
+            ComponentCollection::make(File::files($componentDirectory->getAbsoluteDirectory()))
+                ->filter(function (SplFileInfo $file) {
+                    return Str::endsWith($file->getFilename(), '.blade.php');
+                })
+                ->map(function (SplFileInfo $file) use ($componentDirectory) {
+                    return $componentDirectory->getViewName($file);
+                })
+        );
+    }
+
+    /**
+     * @param iterable|string[] $views
+     *
+     * @return \Spatie\BladeX\ComponentCollection|\Spatie\BladeX\Component[]
+     */
+    protected function registerViews(iterable $views): ComponentCollection
+    {
+        return ComponentCollection::make($views)->map(function (string $viewName) {
+            return $this->component($viewName);
+        });
     }
 }

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -38,9 +38,7 @@ class Compiler
 
     protected function parseSelfClosingTags(string $viewContents, Component $component): string
     {
-        $prefix = $this->bladeX->getPrefix();
-
-        $pattern = "/<\s*{$prefix}{$component->tag}\s*(?<attributes>(?:\s+[\w\-:]+(=(?:\\\"[^\\\"]+\\\"|\'[^\']+\'|[^\'\\\"=<>]+))?)*\s*)\/>/";
+        $pattern = "/<\s*{$component->getTag()}\s*(?<attributes>(?:\s+[\w\-:]+(=(?:\\\"[^\\\"]+\\\"|\'[^\']+\'|[^\'\\\"=<>]+))?)*\s*)\/>/";
 
         return preg_replace_callback($pattern, function (array $matches) use ($component) {
             $attributes = $this->getAttributesFromAttributeString($matches['attributes']);
@@ -51,9 +49,7 @@ class Compiler
 
     protected function parseOpeningTags(string $viewContents, Component $component): string
     {
-        $prefix = $this->bladeX->getPrefix();
-
-        $pattern = "/<\s*{$prefix}{$component->tag}(?<attributes>(?:\s+[\w\-:]+(=(?:\\\"[^\\\"]*\\\"|\'[^\']*\'|[^\'\\\"=<>]+))?)*\s*)(?<![\/=\-])>/";
+        $pattern = "/<\s*{$component->getTag()}(?<attributes>(?:\s+[\w\-:]+(=(?:\\\"[^\\\"]*\\\"|\'[^\']*\'|[^\'\\\"=<>]+))?)*\s*)(?<![\/=\-])>/";
 
         return preg_replace_callback($pattern, function (array $matches) use ($component) {
             $attributes = $this->getAttributesFromAttributeString($matches['attributes']);
@@ -64,9 +60,7 @@ class Compiler
 
     protected function parseClosingTags(string $viewContents, Component $component): string
     {
-        $prefix = $this->bladeX->getPrefix();
-
-        $pattern = "/<\/\s*{$prefix}{$component->tag}\s*>/";
+        $pattern = "/<\/\s*{$component->getTag()}\s*>/";
 
         return preg_replace($pattern, $this->componentEndString($component), $viewContents);
     }
@@ -162,11 +156,6 @@ class Compiler
         $viewContents = preg_replace($closingPattern, ' @endslot', $viewContents);
 
         return $viewContents;
-    }
-
-    protected function isOpeningHtmlTag(string $tagName, string $html): bool
-    {
-        return ! Str::endsWith($html, ["</{$tagName}>", '/>']);
     }
 
     protected function parseBindAttributes(string $attributeString): string

--- a/src/Component.php
+++ b/src/Component.php
@@ -9,34 +9,63 @@ use Spatie\BladeX\Exceptions\CouldNotRegisterComponent;
 
 class Component
 {
+    /** @var BladeX */
+    protected $bladeX;
+
     /** @var string */
     public $view;
 
-    /** @var string */
+    /**
+     * @var string
+     * @internal
+     * @see Component::getTag()
+     */
     public $tag;
 
     /** @var string */
     public $viewModel;
 
-    public static function make(string $view, string $tag = '')
+    /** @var string */
+    protected $prefix;
+
+    /** @var bool */
+    protected $withNamespace;
+
+    public static function make(string $view, string $tag = '', string $prefix = '', bool $withNamespace = true)
     {
-        return new static($view, $tag);
+        return new static($view, $tag, $prefix, $withNamespace);
     }
 
-    public function __construct(string $view, string $tag = '')
+    public function __construct(string $view, string $tag = '', string $prefix = '', bool $withNamespace = true)
     {
-        if ($tag === '') {
-            $tag = $this->determineDefaultTag($view);
-        }
-
         $this->view = $view;
 
         $this->tag = $tag;
+
+        $this->prefix = $prefix;
+
+        $this->withNamespace = $withNamespace;
+
+        $this->bladeX = app(BladeX::class);
     }
 
     public function tag(string $tag)
     {
         $this->tag = $tag;
+
+        return $this;
+    }
+
+    public function prefix(string $prefix)
+    {
+        $this->prefix = $prefix;
+
+        return $this;
+    }
+
+    public function withoutNamespace()
+    {
+        $this->withNamespace = false;
 
         return $this;
     }
@@ -56,15 +85,28 @@ class Component
         return $this;
     }
 
-    protected function determineDefaultTag(string $view): string
+    public function getTag(): string
     {
-        $baseComponentName = explode('.', $view);
+        $tag = empty($this->prefix) ? $this->bladeX->getPrefix() : Str::finish($this->prefix, '-');
+
+        $tag .= empty($this->tag) ? $this->determineDefaultTag() : $this->tag;
+
+        return $tag;
+    }
+
+    protected function determineDefaultTag(): string
+    {
+        $baseComponentName = explode('.', $this->view);
 
         $tag = Str::kebab(end($baseComponentName));
 
-        if (Str::contains($view, '::') && ! Str::contains($tag, '::')) {
-            $namespace = Arr::first(explode('::', $view));
+        if (Str::contains($this->view, '::') && ! Str::contains($tag, '::')) {
+            $namespace = Str::before($this->view, '::');
             $tag = "{$namespace}::{$tag}";
+        }
+
+        if (! $this->withNamespace && Str::contains($tag, '::')) {
+            $tag = Str::after($tag, '::');
         }
 
         return $tag;

--- a/src/Component.php
+++ b/src/Component.php
@@ -2,7 +2,6 @@
 
 namespace Spatie\BladeX;
 
-use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Contracts\Support\Arrayable;
 use Spatie\BladeX\Exceptions\CouldNotRegisterComponent;

--- a/src/ComponentCollection.php
+++ b/src/ComponentCollection.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Spatie\BladeX;
+
+use Illuminate\Support\Collection;
+
+/**
+ * @property-read Component $each
+ */
+class ComponentCollection extends Collection
+{
+    public function prefix(string $prefix)
+    {
+        $this->each->prefix($prefix);
+
+        return $this;
+    }
+
+    public function withoutNamespace()
+    {
+        $this->each->withoutNamespace();
+
+        return $this;
+    }
+}

--- a/src/ComponentDirectory/ComponentDirectory.php
+++ b/src/ComponentDirectory/ComponentDirectory.php
@@ -7,12 +7,15 @@ use Symfony\Component\Finder\SplFileInfo;
 
 abstract class ComponentDirectory
 {
+    /** @var string */
+    protected $viewDirectory;
+
     abstract public function getAbsoluteDirectory(): string;
 
     public function getViewName(SplFileInfo $viewFile): string
     {
         $view = Str::replaceLast('.blade.php', '', $viewFile->getFilename());
 
-        return "{$this->viewDirectory}.{$view}";
+        return empty($this->viewDirectory) ? $view : "{$this->viewDirectory}.{$view}";
     }
 }

--- a/src/ComponentDirectory/NamespacedDirectory.php
+++ b/src/ComponentDirectory/NamespacedDirectory.php
@@ -12,13 +12,10 @@ class NamespacedDirectory extends ComponentDirectory
     /** @var string */
     protected $namespace;
 
-    /** @var string */
-    protected $viewDirectory;
-
     public function __construct(string $viewDirectory)
     {
         [$this->namespace, $viewDirectory] = explode('::', $viewDirectory);
-        $this->viewDirectory = Str::before($viewDirectory, '*');
+        $this->viewDirectory = trim(Str::before($viewDirectory, '*'), '.');
     }
 
     public function getAbsoluteDirectory(): string
@@ -36,14 +33,6 @@ class NamespacedDirectory extends ComponentDirectory
 
     public function getViewName(SplFileInfo $viewFile): string
     {
-        $view = Str::replaceLast('.blade.php', '', $viewFile->getFilename());
-
-        $viewDirectory = '';
-
-        if ($this->viewDirectory !== '') {
-            $viewDirectory = $this->viewDirectory;
-        }
-
-        return "{$this->namespace}::{$viewDirectory}{$view}";
+        return "{$this->namespace}::".parent::getViewName($viewFile);
     }
 }

--- a/src/ComponentDirectory/RegularDirectory.php
+++ b/src/ComponentDirectory/RegularDirectory.php
@@ -9,9 +9,6 @@ use Spatie\BladeX\Exceptions\CouldNotRegisterComponent;
 
 class RegularDirectory extends ComponentDirectory
 {
-    /** @var string */
-    protected $viewDirectory;
-
     public function __construct(string $viewDirectory)
     {
         $this->viewDirectory = Str::before($viewDirectory, '.*');
@@ -33,12 +30,5 @@ class RegularDirectory extends ComponentDirectory
         }
 
         return $absoluteDirectory;
-    }
-
-    public function getViewName(SplFileInfo $viewFile): string
-    {
-        $view = Str::replaceLast('.blade.php', '', $viewFile->getFilename());
-
-        return "{$this->viewDirectory}.{$view}";
     }
 }

--- a/src/ComponentDirectory/RegularDirectory.php
+++ b/src/ComponentDirectory/RegularDirectory.php
@@ -4,7 +4,6 @@ namespace Spatie\BladeX\ComponentDirectory;
 
 use Illuminate\Support\Str;
 use Illuminate\Support\Facades\View;
-use Symfony\Component\Finder\SplFileInfo;
 use Spatie\BladeX\Exceptions\CouldNotRegisterComponent;
 
 class RegularDirectory extends ComponentDirectory

--- a/src/Exceptions/CouldNotRegisterComponent.php
+++ b/src/Exceptions/CouldNotRegisterComponent.php
@@ -31,4 +31,9 @@ class CouldNotRegisterComponent extends Exception
     {
         return new static("Could not register component `{$componentName}` because the view model class `{$viewModelClass}` does not implement `".Arrayable::class.'`.');
     }
+
+    public static function viewDirectoryWithoutWildcard(string $viewDirectory)
+    {
+        return new static("Could not register components because the view directory `{$viewDirectory}` does not end with a wildcard.");
+    }
 }

--- a/src/Facades/BladeX.php
+++ b/src/Facades/BladeX.php
@@ -4,7 +4,15 @@ namespace Spatie\BladeX\Facades;
 
 use Illuminate\Support\Facades\Facade;
 
-/** @see \Spatie\BladeX\BladeX */
+/**
+ * @see \Spatie\BladeX\BladeX
+ *
+ * @method static null|\Spatie\BladeX\Component component($view, string $tag = '')
+ * @method static \Spatie\BladeX\Component[] registeredComponents()
+ * @method static \Spatie\BladeX\BladeX prefix(string $prefix = '')
+ * @method static string getPrefix()
+ * @method static \Spatie\BladeX\ComponentCollection|\Spatie\BladeX\Component[] registerComponents(string $viewDirectory)
+ */
 class BladeX extends Facade
 {
     protected static function getFacadeAccessor()

--- a/src/Facades/BladeX.php
+++ b/src/Facades/BladeX.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Facades\Facade;
  * @see \Spatie\BladeX\BladeX
  *
  * @method static null|\Spatie\BladeX\Component component($view, string $tag = '')
- * @method static \Spatie\BladeX\ComponentCollection|\Spatie\BladeX\Component[] components(string $viewDirectory)
+ * @method static \Spatie\BladeX\ComponentCollection|\Spatie\BladeX\Component[] components(string|string[] $viewDirectory)
  * @method static \Spatie\BladeX\Component[] registeredComponents()
  * @method static \Spatie\BladeX\BladeX prefix(string $prefix = '')
  * @method static string getPrefix()

--- a/src/Facades/BladeX.php
+++ b/src/Facades/BladeX.php
@@ -8,10 +8,10 @@ use Illuminate\Support\Facades\Facade;
  * @see \Spatie\BladeX\BladeX
  *
  * @method static null|\Spatie\BladeX\Component component($view, string $tag = '')
+ * @method static \Spatie\BladeX\ComponentCollection|\Spatie\BladeX\Component[] components(string $viewDirectory)
  * @method static \Spatie\BladeX\Component[] registeredComponents()
  * @method static \Spatie\BladeX\BladeX prefix(string $prefix = '')
  * @method static string getPrefix()
- * @method static \Spatie\BladeX\ComponentCollection|\Spatie\BladeX\Component[] registerComponents(string $viewDirectory)
  */
 class BladeX extends Facade
 {

--- a/tests/Features/Registration/RegistrationTest.php
+++ b/tests/Features/Registration/RegistrationTest.php
@@ -154,6 +154,14 @@ class RegistrationTest extends TestCase
     }
 
     /** @test */
+    public function it_will_throw_an_exception_when_registering_components_without_wildcard()
+    {
+        $this->expectException(CouldNotRegisterComponent::class);
+
+        BladeX::components('components.directoryWithComponents');
+    }
+
+    /** @test */
     public function it_can_register_a_directory_containing_namespaced_view_components()
     {
         View::addNamespace('namespaced-test', __DIR__.'/stubs/components/namespacedComponents');
@@ -382,6 +390,63 @@ class RegistrationTest extends TestCase
             'ns-namespaced-view2' => 'namespaced-test::namespacedView2',
             'ns-namespaced-view3' => 'namespaced-test::namespacedView3',
             'nsc-namespaced-view1' => 'namespaced-test::components.namespacedView1',
+        ], $registeredComponents);
+    }
+
+    /** @test */
+    public function it_can_register_multiple_directories_containing_view_components_with_prefix()
+    {
+        BladeX::components([
+            'components.directoryWithComponents.*',
+            'components.directoryWithComponents2.*',
+        ])->prefix('c');
+
+        $registeredComponents = collect(BladeX::registeredComponents())
+            ->mapWithKeys(function (Component $bladeXComponent) {
+                return [$bladeXComponent->getTag() => $bladeXComponent->view];
+            })
+            ->toArray();
+
+        $this->assertEquals([
+            'c-my-view1' => 'components.directoryWithComponents.myView1',
+            'c-my-view2' => 'components.directoryWithComponents.myView2',
+            'c-my-view3' => 'components.directoryWithComponents.myView3',
+            'c-my-view4' => 'components.directoryWithComponents2.myView4',
+            'c-my-view5' => 'components.directoryWithComponents2.myView5',
+            'c-my-view6' => 'components.directoryWithComponents2.myView6',
+            'context' => 'bladex::context',
+        ], $registeredComponents);
+    }
+
+    /** @test */
+    public function it_can_register_multiple_views_with_prefix()
+    {
+        BladeX::components([
+            'components.directoryWithComponents.myView1',
+            'components.directoryWithComponents.myView2',
+            'components.directoryWithComponents.myView3',
+        ])->prefix('c');
+
+        BladeX::components([
+            'components.directoryWithComponents2.myView4',
+            'components.directoryWithComponents2.myView5',
+            'components.directoryWithComponents2.myView6',
+        ]);
+
+        $registeredComponents = collect(BladeX::registeredComponents())
+            ->mapWithKeys(function (Component $bladeXComponent) {
+                return [$bladeXComponent->getTag() => $bladeXComponent->view];
+            })
+            ->toArray();
+
+        $this->assertEquals([
+            'c-my-view1' => 'components.directoryWithComponents.myView1',
+            'c-my-view2' => 'components.directoryWithComponents.myView2',
+            'c-my-view3' => 'components.directoryWithComponents.myView3',
+            'my-view4' => 'components.directoryWithComponents2.myView4',
+            'my-view5' => 'components.directoryWithComponents2.myView5',
+            'my-view6' => 'components.directoryWithComponents2.myView6',
+            'context' => 'bladex::context',
         ], $registeredComponents);
     }
 }

--- a/tests/Features/Registration/RegistrationTest.php
+++ b/tests/Features/Registration/RegistrationTest.php
@@ -290,9 +290,9 @@ class RegistrationTest extends TestCase
     {
         View::addNamespace('namespaced-test', __DIR__.'/stubs/components/namespacedComponents');
 
-        BladeX::registerComponents('namespaced-test::*')->withoutNamespace();
+        BladeX::components('namespaced-test::*')->withoutNamespace();
 
-        BladeX::registerComponents('namespaced-test::components.*');
+        BladeX::components('namespaced-test::components.*');
 
         $registeredComponents = collect(BladeX::registeredComponents())
             ->mapWithKeys(function (Component $bladeXComponent) {
@@ -316,9 +316,9 @@ class RegistrationTest extends TestCase
 
         BladeX::prefix('x');
 
-        BladeX::registerComponents('namespaced-test::*')->withoutNamespace();
+        BladeX::components('namespaced-test::*')->withoutNamespace();
 
-        BladeX::registerComponents('namespaced-test::components.*');
+        BladeX::components('namespaced-test::components.*');
 
         $registeredComponents = collect(BladeX::registeredComponents())
             ->mapWithKeys(function (Component $bladeXComponent) {
@@ -340,9 +340,9 @@ class RegistrationTest extends TestCase
     {
         View::addNamespace('namespaced-test', __DIR__.'/stubs/components/namespacedComponents');
 
-        BladeX::registerComponents('namespaced-test::*')->withoutNamespace()->prefix('ns');
+        BladeX::components('namespaced-test::*')->withoutNamespace()->prefix('ns');
 
-        BladeX::registerComponents('namespaced-test::components.*');
+        BladeX::components('namespaced-test::components.*');
 
         $registeredComponents = collect(BladeX::registeredComponents())
             ->mapWithKeys(function (Component $bladeXComponent) {
@@ -366,9 +366,9 @@ class RegistrationTest extends TestCase
 
         BladeX::prefix('x');
 
-        BladeX::registerComponents('namespaced-test::*')->withoutNamespace()->prefix('ns');
+        BladeX::components('namespaced-test::*')->withoutNamespace()->prefix('ns');
 
-        BladeX::registerComponents('namespaced-test::components.*')->withoutNamespace()->prefix('nsc');
+        BladeX::components('namespaced-test::components.*')->withoutNamespace()->prefix('nsc');
 
         $registeredComponents = collect(BladeX::registeredComponents())
             ->mapWithKeys(function (Component $bladeXComponent) {

--- a/tests/Features/Registration/RegistrationTest.php
+++ b/tests/Features/Registration/RegistrationTest.php
@@ -27,7 +27,7 @@ class RegistrationTest extends TestCase
         $registeredComponents = BladeX::registeredComponents();
 
         $this->assertEquals('components.directoryWithComponents.myView1', $registeredComponents[1]->view);
-        $this->assertEquals('my-view1', $registeredComponents[1]->tag);
+        $this->assertEquals('my-view1', $registeredComponents[1]->getTag());
     }
 
     /** @test */
@@ -39,7 +39,7 @@ class RegistrationTest extends TestCase
 
         $this->assertCount(2, $registeredComponents);
         $this->assertEquals('components.directoryWithComponents.myView1', $registeredComponents[1]->view);
-        $this->assertEquals('my-custom-tag', $registeredComponents[1]->tag);
+        $this->assertEquals('my-custom-tag', $registeredComponents[1]->getTag());
     }
 
     /** @test */
@@ -53,7 +53,7 @@ class RegistrationTest extends TestCase
 
         $this->assertCount(2, $registeredComponents);
         $this->assertEquals('components.selectField', $registeredComponents[1]->view);
-        $this->assertEquals('my-custom-tag', $registeredComponents[1]->tag);
+        $this->assertEquals('my-custom-tag', $registeredComponents[1]->getTag());
     }
 
     /** @test */
@@ -84,7 +84,7 @@ class RegistrationTest extends TestCase
 
         $registeredComponents = collect(BladeX::registeredComponents())
             ->mapWithKeys(function (Component $bladeXComponent) {
-                return [$bladeXComponent->tag => $bladeXComponent->view];
+                return [$bladeXComponent->getTag() => $bladeXComponent->view];
             })
             ->toArray();
 
@@ -106,7 +106,7 @@ class RegistrationTest extends TestCase
 
         $registeredComponents = collect(BladeX::registeredComponents())
             ->mapWithKeys(function (Component $bladeXComponent) {
-                return [$bladeXComponent->tag => $bladeXComponent->view];
+                return [$bladeXComponent->getTag() => $bladeXComponent->view];
             })
             ->toArray();
 
@@ -146,6 +146,14 @@ class RegistrationTest extends TestCase
     }
 
     /** @test */
+    public function it_will_throw_an_exception_when_registering_a_namespace_that_does_not_exist()
+    {
+        $this->expectException(CouldNotRegisterComponent::class);
+
+        BladeX::component('non-existing-namespace::*');
+    }
+
+    /** @test */
     public function it_can_register_a_directory_containing_namespaced_view_components()
     {
         View::addNamespace('namespaced-test', __DIR__.'/stubs/components/namespacedComponents');
@@ -154,7 +162,7 @@ class RegistrationTest extends TestCase
 
         $registeredComponents = collect(BladeX::registeredComponents())
             ->mapWithKeys(function (Component $bladeXComponent) {
-                return [$bladeXComponent->tag => $bladeXComponent->view];
+                return [$bladeXComponent->getTag() => $bladeXComponent->view];
             })
             ->toArray();
 
@@ -175,7 +183,7 @@ class RegistrationTest extends TestCase
 
         $registeredComponents = collect(BladeX::registeredComponents())
             ->mapWithKeys(function (Component $bladeXComponent) {
-                return [$bladeXComponent->tag => $bladeXComponent->view];
+                return [$bladeXComponent->getTag() => $bladeXComponent->view];
             })
             ->toArray();
 
@@ -194,6 +202,186 @@ class RegistrationTest extends TestCase
         $registeredComponents = BladeX::registeredComponents();
 
         $this->assertEquals('components.directoryWithComponents.myView2', $registeredComponents[1]->view);
-        $this->assertEquals('foo', $registeredComponents[1]->tag);
+        $this->assertEquals('foo', $registeredComponents[1]->getTag());
+    }
+
+    /** @test */
+    public function it_can_register_a_namespaced_view_component_without_namespace()
+    {
+        View::addNamespace('namespaced-test', __DIR__.'/stubs/components/namespacedComponents');
+
+        BladeX::component('namespaced-test::namespacedView1')->withoutNamespace();
+
+        $registeredComponents = collect(BladeX::registeredComponents())
+            ->mapWithKeys(function (Component $bladeXComponent) {
+                return [$bladeXComponent->getTag() => $bladeXComponent->view];
+            })
+            ->toArray();
+
+        $this->assertEquals([
+            'context' => 'bladex::context',
+            'namespaced-view1' => 'namespaced-test::namespacedView1',
+        ], $registeredComponents);
+    }
+
+    /** @test */
+    public function it_can_register_a_namespaced_view_component_without_namespace_but_global_prefix()
+    {
+        View::addNamespace('namespaced-test', __DIR__.'/stubs/components/namespacedComponents');
+
+        BladeX::prefix('x');
+
+        BladeX::component('namespaced-test::namespacedView1')->withoutNamespace();
+
+        $registeredComponents = collect(BladeX::registeredComponents())
+            ->mapWithKeys(function (Component $bladeXComponent) {
+                return [$bladeXComponent->getTag() => $bladeXComponent->view];
+            })
+            ->toArray();
+
+        $this->assertEquals([
+            'x-context' => 'bladex::context',
+            'x-namespaced-view1' => 'namespaced-test::namespacedView1',
+        ], $registeredComponents);
+    }
+
+    /** @test */
+    public function it_can_register_a_namespaced_view_component_without_namespace_but_self_prefix()
+    {
+        View::addNamespace('namespaced-test', __DIR__.'/stubs/components/namespacedComponents');
+
+        BladeX::component('namespaced-test::namespacedView1')->withoutNamespace()->prefix('ns');
+
+        $registeredComponents = collect(BladeX::registeredComponents())
+            ->mapWithKeys(function (Component $bladeXComponent) {
+                return [$bladeXComponent->getTag() => $bladeXComponent->view];
+            })
+            ->toArray();
+
+        $this->assertEquals([
+            'context' => 'bladex::context',
+            'ns-namespaced-view1' => 'namespaced-test::namespacedView1',
+        ], $registeredComponents);
+    }
+
+    /** @test */
+    public function it_can_register_a_namespaced_view_component_without_namespace_but_self_prefix_overrides_global_prefix()
+    {
+        View::addNamespace('namespaced-test', __DIR__.'/stubs/components/namespacedComponents');
+
+        BladeX::prefix('x');
+
+        BladeX::component('namespaced-test::namespacedView1')->withoutNamespace()->prefix('ns');
+
+        $registeredComponents = collect(BladeX::registeredComponents())
+            ->mapWithKeys(function (Component $bladeXComponent) {
+                return [$bladeXComponent->getTag() => $bladeXComponent->view];
+            })
+            ->toArray();
+
+        $this->assertEquals([
+            'x-context' => 'bladex::context',
+            'ns-namespaced-view1' => 'namespaced-test::namespacedView1',
+        ], $registeredComponents);
+    }
+
+    /** @test */
+    public function it_can_register_a_directory_containing_namespaced_view_components_without_namespace()
+    {
+        View::addNamespace('namespaced-test', __DIR__.'/stubs/components/namespacedComponents');
+
+        BladeX::registerComponents('namespaced-test::*')->withoutNamespace();
+
+        BladeX::registerComponents('namespaced-test::components.*');
+
+        $registeredComponents = collect(BladeX::registeredComponents())
+            ->mapWithKeys(function (Component $bladeXComponent) {
+                return [$bladeXComponent->getTag() => $bladeXComponent->view];
+            })
+            ->toArray();
+
+        $this->assertEquals([
+            'context' => 'bladex::context',
+            'namespaced-view1' => 'namespaced-test::namespacedView1',
+            'namespaced-view2' => 'namespaced-test::namespacedView2',
+            'namespaced-view3' => 'namespaced-test::namespacedView3',
+            'namespaced-test::namespaced-view1' => 'namespaced-test::components.namespacedView1',
+        ], $registeredComponents);
+    }
+
+    /** @test */
+    public function it_can_register_a_directory_containing_namespaced_view_components_without_namespace_but_global_prefix()
+    {
+        View::addNamespace('namespaced-test', __DIR__.'/stubs/components/namespacedComponents');
+
+        BladeX::prefix('x');
+
+        BladeX::registerComponents('namespaced-test::*')->withoutNamespace();
+
+        BladeX::registerComponents('namespaced-test::components.*');
+
+        $registeredComponents = collect(BladeX::registeredComponents())
+            ->mapWithKeys(function (Component $bladeXComponent) {
+                return [$bladeXComponent->getTag() => $bladeXComponent->view];
+            })
+            ->toArray();
+
+        $this->assertEquals([
+            'x-context' => 'bladex::context',
+            'x-namespaced-view1' => 'namespaced-test::namespacedView1',
+            'x-namespaced-view2' => 'namespaced-test::namespacedView2',
+            'x-namespaced-view3' => 'namespaced-test::namespacedView3',
+            'x-namespaced-test::namespaced-view1' => 'namespaced-test::components.namespacedView1',
+        ], $registeredComponents);
+    }
+
+    /** @test */
+    public function it_can_register_a_directory_containing_namespaced_view_components_without_namespace_but_self_prefix()
+    {
+        View::addNamespace('namespaced-test', __DIR__.'/stubs/components/namespacedComponents');
+
+        BladeX::registerComponents('namespaced-test::*')->withoutNamespace()->prefix('ns');
+
+        BladeX::registerComponents('namespaced-test::components.*');
+
+        $registeredComponents = collect(BladeX::registeredComponents())
+            ->mapWithKeys(function (Component $bladeXComponent) {
+                return [$bladeXComponent->getTag() => $bladeXComponent->view];
+            })
+            ->toArray();
+
+        $this->assertEquals([
+            'context' => 'bladex::context',
+            'ns-namespaced-view1' => 'namespaced-test::namespacedView1',
+            'ns-namespaced-view2' => 'namespaced-test::namespacedView2',
+            'ns-namespaced-view3' => 'namespaced-test::namespacedView3',
+            'namespaced-test::namespaced-view1' => 'namespaced-test::components.namespacedView1',
+        ], $registeredComponents);
+    }
+
+    /** @test */
+    public function it_can_register_a_directory_containing_namespaced_view_components_without_namespace_but_self_prefix_overrides_global_prefix()
+    {
+        View::addNamespace('namespaced-test', __DIR__.'/stubs/components/namespacedComponents');
+
+        BladeX::prefix('x');
+
+        BladeX::registerComponents('namespaced-test::*')->withoutNamespace()->prefix('ns');
+
+        BladeX::registerComponents('namespaced-test::components.*')->withoutNamespace()->prefix('nsc');
+
+        $registeredComponents = collect(BladeX::registeredComponents())
+            ->mapWithKeys(function (Component $bladeXComponent) {
+                return [$bladeXComponent->getTag() => $bladeXComponent->view];
+            })
+            ->toArray();
+
+        $this->assertEquals([
+            'x-context' => 'bladex::context',
+            'ns-namespaced-view1' => 'namespaced-test::namespacedView1',
+            'ns-namespaced-view2' => 'namespaced-test::namespacedView2',
+            'ns-namespaced-view3' => 'namespaced-test::namespacedView3',
+            'nsc-namespaced-view1' => 'namespaced-test::components.namespacedView1',
+        ], $registeredComponents);
     }
 }


### PR DESCRIPTION
fixes #82 

This PR could be breaking in one way:
The `$component->tag` property is now `@internal` and replaced by `$component->getTag()` method. This is to generate the tag on runtime to handle the new `->prefix()` and `->withoutNamespace()` methods.
So the `$tag` property will be empty if no custom tag is set. In a later release this should be changed to a protected property. If wanted I can also do it in this one.

At all I would say that this shouldn't be a big problem because I think/hope that no one tinkers around with the property in his own code.

To don't change the `\Spatie\BladeX\BladeX::component()` method signature I've added the `\Spatie\BladeX\BladeX::components()` which returns a collection to allow chain of `prefix()` and `withoutNamespace()` methods.

It's also possible to pass a normal wildcard path (without namespace) to the `\Spatie\BladeX\BladeX::components()` method or even an array of view paths or an array of wildcard directories.

If the code is accepted I will for sure update the documentation. For now you can check the added unittests to see what's possible.