### PR TITLE
Allow blade echo statements in attributes

### DIFF
--- a/docs/basic-usage/using-variables.md
+++ b/docs/basic-usage/using-variables.md
@@ -12,14 +12,21 @@ When using a BladeX component all attributes will be passed as variables to the 
 <my-alert type="error">
 ```
 
-If you want to pass on a PHP variable or something that needs to be evaluated you must prefix the attribute name with `:`.
+If you're using basic Blade echo statements, BladeX will handle that for you automatically:
 
 ```html
-{{-- the `myAlert` view will receive the contents of `$message` --}}
-<my-alert type="error" :message="$message">
+{{-- the `myAlert` view will receive a variable named `message` with an HtmlString having the value `'Oops: '.e($message)` --}}
+<my-alert type="error" message="Oops: {{ $message }}">
+```
 
-{{-- the `myAlert` view will receive the uppercased contents of `$message` --}}
-<my-alert type="error" :message="strtoupper($message)">
+Please note that BladeX uses `Illuminate\Support\HtmlString` objects to help prevent double-encoding of variables, 
+so in the edge-case where you absolutely need the variable to be a string, you must cast it using `(string) $message`.
+
+If you want to pass on a something that needs to be evaluated you must prefix the attribute name with `:`.
+
+```html
+{{-- the `myAlert` view will receive the array of messages supplied --}}
+<my-alert type="error" :messages="[$message1, $message2, $message3]">
 ```
 
 Boolean attributes (attributes without a value), e.g. `<checkbox checked />` will be passed to the component as variables evaluating to `true`.

--- a/docs/basic-usage/writing-your-first-component.md
+++ b/docs/basic-usage/writing-your-first-component.md
@@ -51,5 +51,5 @@ In your Blade view you can now use the component using the kebab-cased name:
 ```html
 <h1>My view</h1>
 
-<my-alert type="error" :message="$message" />
+<my-alert type="error" message="{{ $message }}" />
 ```

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -131,10 +131,10 @@ class Compiler
             }
 
             $value = $this->stripQuotes($value);
-            $value = $this->compileEchoes($value);
 
             if (Str::startsWith($attribute, 'bind:')) {
                 $attribute = Str::after($attribute, 'bind:');
+                $value = $this->compileEchoes($value);
             } else {
                 $value = str_replace("'", "\\'", $value);
                 $value = "'{$value}'";

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -181,15 +181,15 @@ class Compiler
 
         return $string;
     }
-    
+
     protected function compileEchoes(string $value): string
     {
         if (preg_match('/\s*{{\s*(.*?)\s*}}\s*/', $value, $echoMatch)) {
             return 'e('.$echoMatch[1].')';
-        } else if (preg_match('/\s*{!!\s*(.*?)\s*!!}\s*/', $value, $unescapedEchoMatch)) {
+        } elseif (preg_match('/\s*{!!\s*(.*?)\s*!!}\s*/', $value, $unescapedEchoMatch)) {
             return $unescapedEchoMatch[1];
         }
-        
+
         return $value;
     }
 }

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -212,7 +212,7 @@ class Compiler
                 return "'".str_replace("'", "\\'", $segment)."'";
             })
             ->implode('.');
-        
+
         return "new \\Illuminate\\Support\\HtmlString({$string})";
     }
 }

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -196,7 +196,7 @@ class Compiler
     {
         $segments = preg_split('/({{\s*.+?\s*}}|{!!\s*.+?\s*!!})/s', $value, -1, PREG_SPLIT_DELIM_CAPTURE);
 
-        return Collection::make($segments)
+        $string = Collection::make($segments)
             ->reject(function ($segment) {
                 return '' === $segment;
             })
@@ -212,5 +212,7 @@ class Compiler
                 return "'".str_replace("'", "\\'", $segment)."'";
             })
             ->implode('.');
+        
+        return "new \\Illuminate\\Support\\HtmlString({$string})";
     }
 }

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -131,6 +131,7 @@ class Compiler
             }
 
             $value = $this->stripQuotes($value);
+            $value = $this->compileEchoes($value);
 
             if (Str::startsWith($attribute, 'bind:')) {
                 $attribute = Str::after($attribute, 'bind:');
@@ -160,7 +161,7 @@ class Compiler
 
     protected function parseBindAttributes(string $attributeString): string
     {
-        return preg_replace("/\s*:([\w-]+)=/m", ' bind:$1=', $attributeString);
+        return preg_replace("/\s*:([\w-]+)(=)|\s*([\w-]+)(=[\'\"]?\s*(?:{{|{!!))/m", ' bind:$1$3$2$4', $attributeString);
     }
 
     protected function attributesToString(array $attributes): string
@@ -179,5 +180,16 @@ class Compiler
         }
 
         return $string;
+    }
+    
+    protected function compileEchoes(string $value): string
+    {
+        if (preg_match('/\s*{{\s*(.*?)\s*}}\s*/', $value, $echoMatch)) {
+            return 'e('.$echoMatch[1].')';
+        } else if (preg_match('/\s*{!!\s*(.*?)\s*!!}\s*/', $value, $unescapedEchoMatch)) {
+            return $unescapedEchoMatch[1];
+        }
+        
+        return $value;
     }
 }

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -2,8 +2,8 @@
 
 namespace Spatie\BladeX;
 
-use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use Illuminate\Support\Collection;
 
 class Compiler
 {
@@ -132,7 +132,7 @@ class Compiler
             }
 
             $value = $this->stripQuotes($value);
-            
+
             if ($this->containsEchoes($value)) {
                 $attribute = Str::start($attribute, 'bind:');
                 $value = $this->compileEchoes($value);
@@ -186,7 +186,7 @@ class Compiler
 
         return $string;
     }
-    
+
     protected function containsEchoes(string $value): bool
     {
         return preg_match('/{{\s*(.+?)\s*}}|{!!\s*(.+?)\s*!!}/s', $value);
@@ -195,20 +195,20 @@ class Compiler
     protected function compileEchoes(string $value): string
     {
         $segments = preg_split('/({{\s*.+?\s*}}|{!!\s*.+?\s*!!})/s', $value, -1, PREG_SPLIT_DELIM_CAPTURE);
-        
+
         return Collection::make($segments)
-            ->reject(function($segment) {
+            ->reject(function ($segment) {
                 return '' === $segment;
             })
-            ->map(function($segment) {
+            ->map(function ($segment) {
                 if (preg_match('/{{\s*(.+?)\s*}}/s', $segment, $matches)) {
                     return 'e('.$matches[1].')';
                 }
-                
+
                 if (preg_match('/{!!\s*(.+?)\s*!!}/s', $segment, $matches)) {
                     return $matches[1];
                 }
-    
+
                 return "'".str_replace("'", "\\'", $segment)."'";
             })
             ->implode('.');

--- a/tests/Features/ComponentCompilation/ComponentCompilationTest.php
+++ b/tests/Features/ComponentCompilation/ComponentCompilationTest.php
@@ -183,12 +183,12 @@ class ComponentCompilationTest extends TestCase
 
         $this->assertMatchesViewSnapshot('componentWithEmptyAttributes');
     }
-    
+
     /** @test */
     public function it_compiles_components_with_blade_echo_statements_in_attributes()
     {
         BladeX::component('components.card');
-        
+
         $this->assertMatchesViewSnapshot('componentWithBladeEchoes');
     }
 }

--- a/tests/Features/ComponentCompilation/ComponentCompilationTest.php
+++ b/tests/Features/ComponentCompilation/ComponentCompilationTest.php
@@ -183,4 +183,12 @@ class ComponentCompilationTest extends TestCase
 
         $this->assertMatchesViewSnapshot('componentWithEmptyAttributes');
     }
+    
+    /** @test */
+    public function it_compiles_components_with_blade_echo_statements_in_attributes()
+    {
+        BladeX::component('components.card');
+        
+        $this->assertMatchesViewSnapshot('componentWithBladeEchoes');
+    }
 }

--- a/tests/Features/ComponentCompilation/__snapshots__/ComponentCompilationTest__it_compiles_components_with_blade_echo_statements_in_attributes__1.xml
+++ b/tests/Features/ComponentCompilation/__snapshots__/ComponentCompilationTest__it_compiles_components_with_blade_echo_statements_in_attributes__1.xml
@@ -5,15 +5,31 @@
     <div>My content</div>
   </div>
   <div class="card">
+    <h1>G'day John!</h1>
+    <div>My content</div>
+  </div>
+  <div class="card">
     <h1>Jane</h1>
     <div>My content</div>
   </div>
   <div class="card">
-    <h1>Blade &amp; XML</h1>
+    <h1>Jane's Page</h1>
     <div>My content</div>
   </div>
   <div class="card">
     <h1>Blade &amp; XML</h1>
+    <div>My content</div>
+  </div>
+  <div class="card">
+    <h1>The "Blade &amp; XML" section</h1>
+    <div>My content</div>
+  </div>
+  <div class="card">
+    <h1>Blade &amp; XML</h1>
+    <div>My content</div>
+  </div>
+  <div class="card">
+    <h1>The "Blade &amp; XML" section</h1>
     <div>My content</div>
   </div>
 </div>

--- a/tests/Features/ComponentCompilation/__snapshots__/ComponentCompilationTest__it_compiles_components_with_blade_echo_statements_in_attributes__1.xml
+++ b/tests/Features/ComponentCompilation/__snapshots__/ComponentCompilationTest__it_compiles_components_with_blade_echo_statements_in_attributes__1.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<div>
+  <div class="card">
+    <h1>John</h1>
+    <div>My content</div>
+  </div>
+  <div class="card">
+    <h1>Jane</h1>
+    <div>My content</div>
+  </div>
+  <div class="card">
+    <h1>Blade &amp; XML</h1>
+    <div>My content</div>
+  </div>
+  <div class="card">
+    <h1>Blade &amp; XML</h1>
+    <div>My content</div>
+  </div>
+</div>

--- a/tests/Features/ComponentCompilation/__snapshots__/ComponentCompilationTest__it_compiles_components_with_blade_echo_statements_in_attributes__2.xml
+++ b/tests/Features/ComponentCompilation/__snapshots__/ComponentCompilationTest__it_compiles_components_with_blade_echo_statements_in_attributes__2.xml
@@ -8,6 +8,13 @@
     My content
  <?php echo $__env->renderComponent(); ?> 
 
+ <?php $__env->startComponent(
+           'components.card',
+           array_merge(app(Spatie\BladeX\ContextStack::class)->read(),
+           ['title' => 'G\'day '.e($user).'!'])
+        ); ?> 
+    My content
+ <?php echo $__env->renderComponent(); ?> 
 
 <?php $user = new class {
         public $name = 'Jane';
@@ -18,6 +25,14 @@
            'components.card',
            array_merge(app(Spatie\BladeX\ContextStack::class)->read(),
            ['title' => e($user->name)])
+        ); ?> 
+    My content
+ <?php echo $__env->renderComponent(); ?> 
+
+ <?php $__env->startComponent(
+           'components.card',
+           array_merge(app(Spatie\BladeX\ContextStack::class)->read(),
+           ['title' => e($user->name).'\'s Page'])
         ); ?> 
     My content
  <?php echo $__env->renderComponent(); ?> 
@@ -33,6 +48,14 @@
     My content
  <?php echo $__env->renderComponent(); ?> 
 
+ <?php $__env->startComponent(
+           'components.card',
+           array_merge(app(Spatie\BladeX\ContextStack::class)->read(),
+           ['title' => 'The &quot;'.e($title).'&quot; section'])
+        ); ?> 
+    My content
+ <?php echo $__env->renderComponent(); ?> 
+
 <?php $title = 'Blade &amp; XML';
 ?>
 
@@ -40,6 +63,14 @@
            'components.card',
            array_merge(app(Spatie\BladeX\ContextStack::class)->read(),
            ['title' => $title])
+        ); ?> 
+    My content
+ <?php echo $__env->renderComponent(); ?> 
+
+ <?php $__env->startComponent(
+           'components.card',
+           array_merge(app(Spatie\BladeX\ContextStack::class)->read(),
+           ['title' => 'The &quot;'.$title.'&quot; section'])
         ); ?> 
     My content
  <?php echo $__env->renderComponent(); ?> 

--- a/tests/Features/ComponentCompilation/__snapshots__/ComponentCompilationTest__it_compiles_components_with_blade_echo_statements_in_attributes__2.xml
+++ b/tests/Features/ComponentCompilation/__snapshots__/ComponentCompilationTest__it_compiles_components_with_blade_echo_statements_in_attributes__2.xml
@@ -3,7 +3,7 @@
 ?><?php $__env->startComponent(
            'components.card',
            array_merge(app(Spatie\BladeX\ContextStack::class)->read(),
-           ['title' => e($user)])
+           ['title' => new \Illuminate\Support\HtmlString(e($user))])
         ); ?> 
     My content
  <?php echo $__env->renderComponent(); ?> 
@@ -11,7 +11,7 @@
  <?php $__env->startComponent(
            'components.card',
            array_merge(app(Spatie\BladeX\ContextStack::class)->read(),
-           ['title' => 'G\'day '.e($user).'!'])
+           ['title' => new \Illuminate\Support\HtmlString('G\'day '.e($user).'!')])
         ); ?> 
     My content
  <?php echo $__env->renderComponent(); ?> 
@@ -24,7 +24,7 @@
  <?php $__env->startComponent(
            'components.card',
            array_merge(app(Spatie\BladeX\ContextStack::class)->read(),
-           ['title' => e($user->name)])
+           ['title' => new \Illuminate\Support\HtmlString(e($user->name))])
         ); ?> 
     My content
  <?php echo $__env->renderComponent(); ?> 
@@ -32,7 +32,7 @@
  <?php $__env->startComponent(
            'components.card',
            array_merge(app(Spatie\BladeX\ContextStack::class)->read(),
-           ['title' => e($user->name).'\'s Page'])
+           ['title' => new \Illuminate\Support\HtmlString(e($user->name).'\'s Page')])
         ); ?> 
     My content
  <?php echo $__env->renderComponent(); ?> 
@@ -43,7 +43,7 @@
  <?php $__env->startComponent(
            'components.card',
            array_merge(app(Spatie\BladeX\ContextStack::class)->read(),
-           ['title' => e($title)])
+           ['title' => new \Illuminate\Support\HtmlString(e($title))])
         ); ?> 
     My content
  <?php echo $__env->renderComponent(); ?> 
@@ -51,7 +51,7 @@
  <?php $__env->startComponent(
            'components.card',
            array_merge(app(Spatie\BladeX\ContextStack::class)->read(),
-           ['title' => 'The &quot;'.e($title).'&quot; section'])
+           ['title' => new \Illuminate\Support\HtmlString('The &quot;'.e($title).'&quot; section')])
         ); ?> 
     My content
  <?php echo $__env->renderComponent(); ?> 
@@ -62,7 +62,7 @@
  <?php $__env->startComponent(
            'components.card',
            array_merge(app(Spatie\BladeX\ContextStack::class)->read(),
-           ['title' => $title])
+           ['title' => new \Illuminate\Support\HtmlString($title)])
         ); ?> 
     My content
  <?php echo $__env->renderComponent(); ?> 
@@ -70,7 +70,7 @@
  <?php $__env->startComponent(
            'components.card',
            array_merge(app(Spatie\BladeX\ContextStack::class)->read(),
-           ['title' => 'The &quot;'.$title.'&quot; section'])
+           ['title' => new \Illuminate\Support\HtmlString('The &quot;'.$title.'&quot; section')])
         ); ?> 
     My content
  <?php echo $__env->renderComponent(); ?> 

--- a/tests/Features/ComponentCompilation/__snapshots__/ComponentCompilationTest__it_compiles_components_with_blade_echo_statements_in_attributes__2.xml
+++ b/tests/Features/ComponentCompilation/__snapshots__/ComponentCompilationTest__it_compiles_components_with_blade_echo_statements_in_attributes__2.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<div><?php $user = 'John';
+?><?php $__env->startComponent(
+           'components.card',
+           array_merge(app(Spatie\BladeX\ContextStack::class)->read(),
+           ['title' => e($user)])
+        ); ?> 
+    My content
+ <?php echo $__env->renderComponent(); ?> 
+
+
+<?php $user = new class {
+        public $name = 'Jane';
+    };
+?>
+
+ <?php $__env->startComponent(
+           'components.card',
+           array_merge(app(Spatie\BladeX\ContextStack::class)->read(),
+           ['title' => e($user->name)])
+        ); ?> 
+    My content
+ <?php echo $__env->renderComponent(); ?> 
+
+<?php $title = 'Blade & XML';
+?>
+
+ <?php $__env->startComponent(
+           'components.card',
+           array_merge(app(Spatie\BladeX\ContextStack::class)->read(),
+           ['title' => e($title)])
+        ); ?> 
+    My content
+ <?php echo $__env->renderComponent(); ?> 
+
+<?php $title = 'Blade &amp; XML';
+?>
+
+ <?php $__env->startComponent(
+           'components.card',
+           array_merge(app(Spatie\BladeX\ContextStack::class)->read(),
+           ['title' => $title])
+        ); ?> 
+    My content
+ <?php echo $__env->renderComponent(); ?> 
+</div>

--- a/tests/Features/ComponentCompilation/stubs/views/componentWithBladeEchoes.blade.php
+++ b/tests/Features/ComponentCompilation/stubs/views/componentWithBladeEchoes.blade.php
@@ -8,6 +8,9 @@
     My content
 </card>
 
+<card title="G'day {{ $user }}!">
+    My content
+</card>
 
 @php
     $user = new class {
@@ -19,6 +22,10 @@
     My content
 </card>
 
+<card title="{{ $user->name }}'s Page">
+    My content
+</card>
+
 @php
     $title = 'Blade & XML';
 @endphp
@@ -27,10 +34,18 @@
     My content
 </card>
 
+<card title="The &quot;{{ $title }}&quot; section">
+    My content
+</card>
+
 @php
     $title = 'Blade &amp; XML';
 @endphp
 
 <card title="{!! $title !!}">
+    My content
+</card>
+
+<card title="The &quot;{!! $title !!}&quot; section">
     My content
 </card>

--- a/tests/Features/ComponentCompilation/stubs/views/componentWithBladeEchoes.blade.php
+++ b/tests/Features/ComponentCompilation/stubs/views/componentWithBladeEchoes.blade.php
@@ -1,0 +1,36 @@
+
+
+@php
+    $user = 'John';
+@endphp
+
+<card title="{{ $user }}">
+    My content
+</card>
+
+
+@php
+    $user = new class {
+        public $name = 'Jane';
+    };
+@endphp
+
+<card title="{{ $user->name }}">
+    My content
+</card>
+
+@php
+    $title = 'Blade & XML';
+@endphp
+
+<card title="{{ $title }}">
+    My content
+</card>
+
+@php
+    $title = 'Blade &amp; XML';
+@endphp
+
+<card title="{!! $title !!}">
+    My content
+</card>


### PR DESCRIPTION
Currently, Blade X requires using `:prefixed-attributes` for binding, which doesn't allow for easy refactoring/autocomplete/syntax highlighting in an IDE that can parse Blade (like PhpStorm). This PR adds support for Blade echo statements inside of attributes, such as:

```php
<card title="{{ $title }}">
  My card
</card>
```

And:

```php
<card title="{!! $title_html !!}">
  My card
</card>
```