### PR TITLE
Update Docs to reflect the laravel 5.8 requirement

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -5,4 +5,4 @@ weight: 3
 
 This package requires:
 - PHP 7.2 or higher 
-- Laravel 5.5.0 or higher
+- Laravel 5.8.0 or higher


### PR DESCRIPTION
Since version 2.2 Laravel 5.8 has been a requirement and I've updated the docs accordingly.

It would be possible to add a note for users with Laravel 5.6/5.7 to use version ^2.1, but I don't know if that is something you want in your docs, as that indicates that you are maintaining support for that.