### PR TITLE
Support namespaced attributes

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -260,6 +260,7 @@ class Compiler
                 if (is_array($value)) {
                     $value = '['.$this->attributesToString($value).']';
                 }
+
                 return "'{$attribute}' => {$value}";
             })
             ->implode(',');

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -201,7 +201,7 @@ class Compiler
 
                 if (Str::contains($attribute, ':')) {
                     $namespace = Str::before($attribute, ':');
-                    if (!$namespaces->has($namespace)) {
+                    if (! $namespaces->has($namespace)) {
                         $namespaces->put($namespace, collect());
                     }
 
@@ -258,7 +258,7 @@ class Compiler
         return collect($attributes)
             ->map(function ($value, string $attribute) {
                 if (is_array($value)) {
-                    $value = '['. $this->attributesToString($value) .']';
+                    $value = '['.$this->attributesToString($value).']';
                 }
                 return "'{$attribute}' => {$value}";
             })

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -46,7 +46,7 @@ class Compiler
                 (?<attributes>
                     (?:
                         \s+
-                        [\w\-:]+
+                        [\w\-:.]+
                         (
                             =
                             (?:
@@ -79,7 +79,7 @@ class Compiler
                 (?<attributes>
                     (?:
                         \s+
-                        [\w\-:]+
+                        [\w\-:.]+
                         (
                             =
                             (?:
@@ -162,7 +162,7 @@ class Compiler
         $attributeString = $this->parseBindAttributes($attributeString);
 
         $pattern = '/
-            (?<attribute>[\w:-]+)
+            (?<attribute>[\w\-:.]+)
             (
                 =
                 (?<value>
@@ -181,7 +181,8 @@ class Compiler
             return [];
         }
 
-        return collect($matches)->mapWithKeys(function ($match) {
+        $namespaces = collect();
+        $attributes = collect($matches)->mapWithKeys(function ($match) use ($namespaces) {
             $attribute = Str::camel($match['attribute']);
             $value = $match['value'] ?? null;
 
@@ -197,10 +198,24 @@ class Compiler
             } else {
                 $value = str_replace("'", "\\'", $value);
                 $value = "'{$value}'";
+
+                if (Str::contains($attribute, ':')) {
+                    $namespace = Str::before($attribute, ':');
+                    if (!$namespaces->has($namespace)) {
+                        $namespaces->put($namespace, collect());
+                    }
+
+                    $attribute = Str::after($attribute, ':');
+                    $namespaces[$namespace]->put($attribute, $value);
+
+                    return [];
+                }
             }
 
             return [$attribute => $value];
-        })->toArray();
+        });
+
+        return $attributes->merge($namespaces)->toArray();
     }
 
     protected function parseSlots(string $viewContents): string
@@ -241,7 +256,10 @@ class Compiler
     protected function attributesToString(array $attributes): string
     {
         return collect($attributes)
-            ->map(function (string $value, string $attribute) {
+            ->map(function ($value, string $attribute) {
+                if (is_array($value)) {
+                    $value = '['. $this->attributesToString($value) .']';
+                }
                 return "'{$attribute}' => {$value}";
             })
             ->implode(',');

--- a/tests/Features/ComponentCompilation/ComponentCompilationTest.php
+++ b/tests/Features/ComponentCompilation/ComponentCompilationTest.php
@@ -191,4 +191,12 @@ class ComponentCompilationTest extends TestCase
 
         $this->assertMatchesViewSnapshot('livewireAttributes');
     }
+
+    /** @test */
+    public function it_compiles_namespaced_attributes_syntax()
+    {
+        BladeX::component('components.textField');
+
+        $this->assertMatchesViewSnapshot('namespacedAttributes');
+    }
 }

--- a/tests/Features/ComponentCompilation/__snapshots__/ComponentCompilationTest__it_compiles_livewire_syntax__2.xml
+++ b/tests/Features/ComponentCompilation/__snapshots__/ComponentCompilationTest__it_compiles_livewire_syntax__2.xml
@@ -3,7 +3,7 @@
   <?php $__env->startComponent(
            'components.textField',
            array_merge(app(Spatie\BladeX\ContextStack::class)->read(),
-           ['name' => 'email','label' => 'Email','wire:model' => 'email'])
+           ['name' => 'email','label' => 'Email','wire' => ['model' => 'email']])
         ); ?>
   <?php echo $__env->renderComponent(); ?>
 </div>

--- a/tests/Features/ComponentCompilation/__snapshots__/ComponentCompilationTest__it_compiles_namespaced_attributes_syntax__1.xml
+++ b/tests/Features/ComponentCompilation/__snapshots__/ComponentCompilationTest__it_compiles_namespaced_attributes_syntax__1.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<div>
+  <div>
+    <label for="email">Email</label>
+    <input type="text" name="email" id="email" value=""/>
+  </div>
+</div>

--- a/tests/Features/ComponentCompilation/__snapshots__/ComponentCompilationTest__it_compiles_namespaced_attributes_syntax__2.xml
+++ b/tests/Features/ComponentCompilation/__snapshots__/ComponentCompilationTest__it_compiles_namespaced_attributes_syntax__2.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<div>
+  <?php $__env->startComponent(
+           'components.textField',
+           array_merge(app(Spatie\BladeX\ContextStack::class)->read(),
+           ['name' => 'email','label' => 'Email','wire.click' => 'validate','wire' => ['model.lazy' => 'email'],'ns1' => ['attr1' => 'ns1\'s value 1','attr2' => 'ns1\'s value 2'],'ns2' => ['attr' => 'ns2\'s value']])
+        ); ?>
+  <?php echo $__env->renderComponent(); ?>
+</div>

--- a/tests/Features/ComponentCompilation/stubs/views/namespacedAttributes.blade.php
+++ b/tests/Features/ComponentCompilation/stubs/views/namespacedAttributes.blade.php
@@ -1,0 +1,4 @@
+<text-field name="email" label="Email"
+            wire:model.lazy="email" wire.click="validate"
+            ns1:attr1="ns1's value 1" ns1:attr2="ns1's value 2"
+            ns2:attr="ns2's value" />


### PR DESCRIPTION
Support for attributes that can be grouped by a "namespace", like
Livewire (#99). Attributes will be available as an array with the
namespace name.

For example, in component:
```blade
    <component ns:attr1="value 1" ns:attr2="value 2" />
```
There will be a `$ns` variable: `['attr1' => 'value1', 'attr2' => 'value 2']`

I haven't added any tests because I don't really understand how testing is being done, with XML snapshots (!?). If you can point me in the right direction I'll gladly add them.
