### PR TITLE
add attribute spread operator

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -46,7 +46,7 @@ class Compiler
                 (?<attributes>
                     (?:
                         \s+
-                        [\w\-:.]+
+                        [\w\-:.\$]+
                         (
                             =
                             (?:
@@ -79,7 +79,7 @@ class Compiler
                 (?<attributes>
                     (?:
                         \s+
-                        [\w\-:.]+
+                        [\w\-:.\$]+
                         (
                             =
                             (?:
@@ -160,7 +160,7 @@ class Compiler
         $attributeString = $this->parseBindAttributes($attributeString);
 
         $pattern = '/
-            (?<attribute>[\w\-:.]+)
+            (?<attribute>[\w\-:.\$]+)
             (
                 =
                 (?<value>
@@ -256,7 +256,7 @@ class Compiler
 
         $plainAttributes = $attributes
             ->reject(function ($value, string $attribute) {
-                return Str::startsWith($attribute, '...');
+                return Str::startsWith($attribute, '...$');
             })
             ->map(function ($value, string $attribute) {
                 if (is_array($value)) {
@@ -270,12 +270,12 @@ class Compiler
 
         $string['spread'] = $attributes
                 ->filter(function ($value, string $attribute) {
-                    return Str::startsWith($attribute, '...');
+                    return Str::startsWith($attribute, '...$');
                 })
                 ->map(function ($value, string $attribute) {
                     $attribute = Str::after($attribute, '...');
 
-                    return "\${$attribute}";
+                    return "{$attribute}";
                 })
                 ->implode(',');
 

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -255,7 +255,7 @@ class Compiler
         $string = [];
 
         $string['plain'] = '['.$attributes
-                ->reject(function($value, string $attribute): bool {
+                ->reject(function ($value, string $attribute) {
                     return Str::startsWith($attribute, '...');
                 })
                 ->map(function ($value, string $attribute) {
@@ -268,7 +268,7 @@ class Compiler
                 ->implode(',').']';
 
         $string['spread'] = $attributes
-                ->filter(function($value, string $attribute): bool {
+                ->filter(function ($value, string $attribute) {
                     return Str::startsWith($attribute, '...');
                 })
                 ->map(function ($value, string $attribute) {

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -254,18 +254,19 @@ class Compiler
 
         $string = [];
 
-        $string['plain'] = '['.$attributes
-                ->reject(function ($value, string $attribute) {
-                    return Str::startsWith($attribute, '...');
-                })
-                ->map(function ($value, string $attribute) {
-                    if (is_array($value)) {
-                        $value = $this->attributesToString($value);
-                    }
+        $plainAttributes = $attributes
+            ->reject(function ($value, string $attribute) {
+                return Str::startsWith($attribute, '...');
+            })
+            ->map(function ($value, string $attribute) {
+                if (is_array($value)) {
+                    $value = $this->attributesToString($value);
+                }
 
-                    return "'{$attribute}' => {$value}";
-                })
-                ->implode(',').']';
+                return "'{$attribute}' => {$value}";
+            });
+
+        $string['plain'] = '['.$plainAttributes->implode(',').']';
 
         $string['spread'] = $attributes
                 ->filter(function ($value, string $attribute) {

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -120,8 +120,6 @@ class Compiler
     {
         $attributesString = $this->attributesToString($attributes);
 
-//        dd($attributesString);
-
         if ($component->view === 'bladex::context') {
             return " @php(app(Spatie\BladeX\ContextStack::class)->push({$attributesString})) ";
         }

--- a/tests/Features/ComponentCompilation/ComponentCompilationTest.php
+++ b/tests/Features/ComponentCompilation/ComponentCompilationTest.php
@@ -199,4 +199,20 @@ class ComponentCompilationTest extends TestCase
 
         $this->assertMatchesViewSnapshot('namespacedAttributes');
     }
+
+    /** @test */
+    public function it_compiles_a_attribute_spread_component()
+    {
+        BladeX::component('components.textField');
+
+        $this->assertMatchesViewSnapshot('spreadAttributes', [
+            'input' => [
+                'name' => 'email',
+                'label' => 'e-mail',
+                'type' => 'email',
+                'value' => 'example@domain.tld',
+            ],
+            'foo' => 'bar',
+        ]);
+    }
 }

--- a/tests/Features/ComponentCompilation/ComponentCompilationTest.php
+++ b/tests/Features/ComponentCompilation/ComponentCompilationTest.php
@@ -212,6 +212,9 @@ class ComponentCompilationTest extends TestCase
                 'type' => 'email',
                 'value' => 'example@domain.tld',
             ],
+            'email' => [
+                'value' => 'blade-x@spatie.be',
+            ],
             'foo' => 'bar',
         ]);
     }

--- a/tests/Features/ComponentCompilation/__snapshots__/ComponentCompilationTest__it_compiles_a_attribute_spread_component__1.xml
+++ b/tests/Features/ComponentCompilation/__snapshots__/ComponentCompilationTest__it_compiles_a_attribute_spread_component__1.xml
@@ -2,6 +2,6 @@
 <div>
   <div>
     <label for="email">E-Mail</label>
-    <input type="email" name="email" id="email" value="example@domain.tld"/>
+    <input type="email" name="email" id="email" value="blade-x@spatie.be"/>
   </div>
 </div>

--- a/tests/Features/ComponentCompilation/__snapshots__/ComponentCompilationTest__it_compiles_a_attribute_spread_component__1.xml
+++ b/tests/Features/ComponentCompilation/__snapshots__/ComponentCompilationTest__it_compiles_a_attribute_spread_component__1.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<div>
+  <div>
+    <label for="email">E-Mail</label>
+    <input type="email" name="email" id="email" value="example@domain.tld"/>
+  </div>
+</div>

--- a/tests/Features/ComponentCompilation/__snapshots__/ComponentCompilationTest__it_compiles_a_attribute_spread_component__2.xml
+++ b/tests/Features/ComponentCompilation/__snapshots__/ComponentCompilationTest__it_compiles_a_attribute_spread_component__2.xml
@@ -3,7 +3,7 @@
   <?php $__env->startComponent(
            'components.textField',
            array_merge(app(Spatie\BladeX\ContextStack::class)->read(),
-           array_merge($input,['before' => 'the spreaded attribute','var' => $foo,'text' => 'true','label' => 'E-Mail']))
+           array_merge($input,$email,['before' => 'the spreaded attribute','var' => $foo,'text' => 'true','label' => 'E-Mail']))
         ); ?>
   <?php echo $__env->renderComponent(); ?>
 </div>

--- a/tests/Features/ComponentCompilation/__snapshots__/ComponentCompilationTest__it_compiles_a_attribute_spread_component__2.xml
+++ b/tests/Features/ComponentCompilation/__snapshots__/ComponentCompilationTest__it_compiles_a_attribute_spread_component__2.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<div>
+  <?php $__env->startComponent(
+           'components.textField',
+           array_merge(app(Spatie\BladeX\ContextStack::class)->read(),
+           array_merge($input,['before' => 'the spreaded attribute','var' => $foo,'text' => 'true','label' => 'E-Mail']))
+        ); ?>
+  <?php echo $__env->renderComponent(); ?>
+</div>

--- a/tests/Features/ComponentCompilation/stubs/views/spreadAttributes.blade.php
+++ b/tests/Features/ComponentCompilation/stubs/views/spreadAttributes.blade.php
@@ -1,1 +1,1 @@
-<text-field before="the spreaded attribute" ...input ...email :var="$foo" text="true" label="E-Mail" />
+<text-field before="the spreaded attribute" ...$input ...$email :var="$foo" text="true" label="E-Mail" />

--- a/tests/Features/ComponentCompilation/stubs/views/spreadAttributes.blade.php
+++ b/tests/Features/ComponentCompilation/stubs/views/spreadAttributes.blade.php
@@ -1,1 +1,1 @@
-<text-field before="the spreaded attribute" ...input :var="$foo" text="true" label="E-Mail" />
+<text-field before="the spreaded attribute" ...input ...email :var="$foo" text="true" label="E-Mail" />

--- a/tests/Features/ComponentCompilation/stubs/views/spreadAttributes.blade.php
+++ b/tests/Features/ComponentCompilation/stubs/views/spreadAttributes.blade.php
@@ -1,0 +1,1 @@
+<text-field before="the spreaded attribute" ...input :var="$foo" text="true" label="E-Mail" />


### PR DESCRIPTION
solves #97 

@AlexVanderbist this is the first solution I've found. It uses `array_merge()` to combine the spreaded attribute with the normal ones.

What do you think?

If any attribute is available twice the priority is right over left and plain over spread. The added test case covers this.
```html
<text-field 
  before="the spreaded attribute" 
  ...$input 
  ...$email 
  :var="$foo"
  text="true" 
  label="E-Mail"
/>
```

```php
array_merge($input,$email,['before' => 'the spreaded attribute','var' => $foo,'text' => 'true','label' => 'E-Mail']))
```